### PR TITLE
wes/working with nx metro config

### DIFF
--- a/apps/sample-expo-app/metro.config.js
+++ b/apps/sample-expo-app/metro.config.js
@@ -5,5 +5,6 @@ const defaultConfig = getDefaultConfig(__dirname);
 const defaultConfigCopy = { ...defaultConfig };
 const withNXMetroConfig = withNxMetro(defaultConfig);
 withNXMetroConfig.transformer.enableBabelRCLookup = true;
+withNXMetroConfig.resolver.resolveRequest = null;
 
 module.exports = withNXMetroConfig;

--- a/apps/sample-expo-app/metro.config.js
+++ b/apps/sample-expo-app/metro.config.js
@@ -1,4 +1,9 @@
+const { withNxMetro } = require('nx-react-native-expo');
 const { getDefaultConfig } = require('@expo/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
-module.exports = defaultConfig;
+const defaultConfigCopy = { ...defaultConfig };
+const withNXMetroConfig = withNxMetro(defaultConfig);
+withNXMetroConfig.transformer.enableBabelRCLookup = true;
+
+module.exports = withNXMetroConfig;

--- a/apps/sample-expo-app/metro.config.js
+++ b/apps/sample-expo-app/metro.config.js
@@ -1,5 +1,4 @@
-const { withNxMetro } = require('nx-react-native-expo');
 const { getDefaultConfig } = require('@expo/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
-module.exports = withNxMetro(defaultConfig);
+module.exports = defaultConfig;

--- a/apps/sample-expo-app/metro.config.js
+++ b/apps/sample-expo-app/metro.config.js
@@ -6,5 +6,6 @@ const defaultConfigCopy = { ...defaultConfig };
 const withNXMetroConfig = withNxMetro(defaultConfigCopy);
 // withNXMetroConfig.transformer.enableBabelRCLookup = true;
 // withNXMetroConfig.resolver.resolveRequest = null;
+withNXMetroConfig.watchFolders = [];
 
 module.exports = withNXMetroConfig;

--- a/apps/sample-expo-app/metro.config.js
+++ b/apps/sample-expo-app/metro.config.js
@@ -3,8 +3,8 @@ const { getDefaultConfig } = require('@expo/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
 const defaultConfigCopy = { ...defaultConfig };
-const withNXMetroConfig = withNxMetro(defaultConfig);
-withNXMetroConfig.transformer.enableBabelRCLookup = true;
-withNXMetroConfig.resolver.resolveRequest = null;
+const withNXMetroConfig = withNxMetro(defaultConfigCopy);
+// withNXMetroConfig.transformer.enableBabelRCLookup = true;
+// withNXMetroConfig.resolver.resolveRequest = null;
 
 module.exports = withNXMetroConfig;

--- a/apps/sample-expo-app/package.json
+++ b/apps/sample-expo-app/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react-native": "*",
     "expo": "*",
-    "@nrwl/workspace": "12.5.0",
-    "nx-react-native-expo": "^0.0.9"
+    "@nrwl/workspace": "*",
+    "nx-react-native-expo": "*"
   }
 }


### PR DESCRIPTION
`watchFolders` is most likely only needed for local development in a NX monorepo context. By setting it back to `[]`, EAS is now building successfully.

Note the matching commit hash.

![image](https://user-images.githubusercontent.com/7388796/125376164-4d0bdd00-e33f-11eb-828a-cfa4b6f917b4.png)
